### PR TITLE
Add new param `mysql_charset` to toml file for setting client's encoding

### DIFF
--- a/lib/qrunner.rb
+++ b/lib/qrunner.rb
@@ -107,7 +107,8 @@ def mysql_client
   @mysql_client ||= Mysql2::Client.new(host: gateway? ? '127.0.0.1' : host,
                                        port: port,
                                        username: mysql_username,
-                                       password: mysql_password)
+                                       password: mysql_password,
+                                       encoding: charset_name)
 end
 
 def host
@@ -120,6 +121,10 @@ def port
             else
               3306
             end
+end
+
+def charset_name
+  @charset_name ||= server_config[service][host_name]['charset_name'] || 'utf8'
 end
 
 def mysql_username
@@ -184,6 +189,5 @@ end
 def exec_mode
   @exec_mode ||= ENV.fetch('EXEC_MODE', 'local')
 end
-
 
 run_query if $PROGRAM_NAME == __FILE__

--- a/lib/qrunner.rb
+++ b/lib/qrunner.rb
@@ -12,8 +12,10 @@ def run_query
     puts '=' * 80,
          "sending queries for #{host}"
     query_list.each_with_index { |q, i|
-      mysql_client.query("#{q};")
       puts "#{i + 1}:\n #{q};"
+      q.encode!(encoding) if do_encoding?
+      mysql_client.query("#{q};")
+
     }
     puts '=' * 80
   end
@@ -108,7 +110,7 @@ def mysql_client
                                        port: port,
                                        username: mysql_username,
                                        password: mysql_password,
-                                       encoding: charset_name)
+                                       encoding: mysql_charset)
 end
 
 def host
@@ -123,8 +125,16 @@ def port
             end
 end
 
-def charset_name
-  @charset_name ||= server_config[service][host_name]['charset_name'] || 'utf8'
+def mysql_charset
+  @charset_name ||= server_config[service][host_name]['mysql_charset'] || 'utf8'
+end
+
+def encoding
+  @encoding ||= server_config[service][host_name]['encoding'] || 'UTF-8'
+end
+
+def do_encoding?
+  mysql_charset != 'utf8' && encoding != 'UTF-8'
 end
 
 def mysql_username

--- a/lib/qrunner.rb
+++ b/lib/qrunner.rb
@@ -124,7 +124,7 @@ def port
 end
 
 def mysql_charset
-  @charset_name ||= server_config[service][host_name]['mysql_charset'] || 'utf8'
+  @mysql_charset ||= server_config[service][host_name]['mysql_charset'] || 'utf8'
 end
 
 def mysql_username

--- a/lib/qrunner.rb
+++ b/lib/qrunner.rb
@@ -12,10 +12,8 @@ def run_query
     puts '=' * 80,
          "sending queries for #{host}"
     query_list.each_with_index { |q, i|
-      puts "#{i + 1}:\n #{q};"
-      q.encode!(encoding) if do_encoding?
       mysql_client.query("#{q};")
-
+      puts "#{i + 1}:\n #{q};"
     }
     puts '=' * 80
   end
@@ -127,14 +125,6 @@ end
 
 def mysql_charset
   @charset_name ||= server_config[service][host_name]['mysql_charset'] || 'utf8'
-end
-
-def encoding
-  @encoding ||= server_config[service][host_name]['encoding'] || 'UTF-8'
-end
-
-def do_encoding?
-  mysql_charset != 'utf8' && encoding != 'UTF-8'
 end
 
 def mysql_username

--- a/lib/qrunner.rb
+++ b/lib/qrunner.rb
@@ -190,4 +190,5 @@ def exec_mode
   @exec_mode ||= ENV.fetch('EXEC_MODE', 'local')
 end
 
+
 run_query if $PROGRAM_NAME == __FILE__

--- a/servers.toml
+++ b/servers.toml
@@ -4,3 +4,4 @@
 host_name = "mydb.tsurubee.jp"
 port = 3307
 ssh_gateway = "qrunner@ssh-gateway.tsurubee.jp"
+charset_name = "ujis"

--- a/servers.toml
+++ b/servers.toml
@@ -5,4 +5,3 @@ host_name = "mydb.tsurubee.jp"
 port = 3307
 ssh_gateway = "qrunner@ssh-gateway.tsurubee.jp"
 mysql_charset = "ujis"
-encoding = "EUC-JP"

--- a/servers.toml
+++ b/servers.toml
@@ -4,4 +4,5 @@
 host_name = "mydb.tsurubee.jp"
 port = 3307
 ssh_gateway = "qrunner@ssh-gateway.tsurubee.jp"
-charset_name = "ujis"
+mysql_charset = "ujis"
+encoding = "EUC-JP"


### PR DESCRIPTION
## What is this PR for?
qrunner runs queries with utf8 by default.  
If charset of server is set other than utf8, and `skip-character-set-client-handshake` is set to true, it is necessary to convert character code on qrunner side to prevent garbled characters.  
That' why I add new param `mysql_charset` to toml file for setting client's encoding.  